### PR TITLE
Provide hard upper limit capability for sending max batch size

### DIFF
--- a/processor/README.md
+++ b/processor/README.md
@@ -264,6 +264,8 @@ Please refer to [config.go](batchprocessor/config.go) for the config spec.
 The following configuration options can be modified:
 - `send_batch_size` (default = 8192): Number of spans after which a batch will 
 be sent.
+- `send_batch_hard_limit` (default = 0 - no limit): Maximum number of spans in a batch. If
+more spans are present, batch will be split into smaller ones. 0 means no limit.
 - `timeout` (default = 200ms): Time duration after which a batch will be sent
 regardless of size.
 

--- a/processor/batchprocessor/config.go
+++ b/processor/batchprocessor/config.go
@@ -29,4 +29,7 @@ type Config struct {
 
 	// SendBatchSize is the size of a batch which after hit, will trigger it to be sent.
 	SendBatchSize uint32 `mapstructure:"send_batch_size,omitempty"`
+
+	// SendBatchHardLimit is the maximum size of a batch. If exceeded, the batch will be split. If 0, then no limit is applied
+	SendBatchHardLimit uint32 `mapstructure:"send_batch_hard_limit,omitempty"`
 }

--- a/processor/batchprocessor/config_test.go
+++ b/processor/batchprocessor/config_test.go
@@ -44,6 +44,7 @@ func TestLoadConfig(t *testing.T) {
 
 	timeout := time.Second * 10
 	sendBatchSize := uint32(10000)
+	sendBatchHardLimit := uint32(30000)
 
 	assert.Equal(t, p1,
 		&Config{
@@ -51,7 +52,8 @@ func TestLoadConfig(t *testing.T) {
 				TypeVal: "batch",
 				NameVal: "batch/2",
 			},
-			SendBatchSize: sendBatchSize,
-			Timeout:       timeout,
+			SendBatchSize:      sendBatchSize,
+			SendBatchHardLimit: sendBatchHardLimit,
+			Timeout:            timeout,
 		})
 }

--- a/processor/batchprocessor/factory.go
+++ b/processor/batchprocessor/factory.go
@@ -28,8 +28,9 @@ const (
 	// The value of "type" key in configuration.
 	typeStr = "batch"
 
-	defaultSendBatchSize = uint32(8192)
-	defaultTimeout       = 200 * time.Millisecond
+	defaultSendBatchSize      = uint32(8192)
+	defaultSendBatchHardLimit = uint32(0)
+	defaultTimeout            = 200 * time.Millisecond
 )
 
 // Factory is the factory for batch processor.
@@ -73,7 +74,8 @@ func generateDefaultConfig() *Config {
 			TypeVal: typeStr,
 			NameVal: typeStr,
 		},
-		SendBatchSize: defaultSendBatchSize,
-		Timeout:       defaultTimeout,
+		SendBatchSize:      defaultSendBatchSize,
+		SendBatchHardLimit: defaultSendBatchHardLimit,
+		Timeout:            defaultTimeout,
 	}
 }

--- a/processor/batchprocessor/splitter.go
+++ b/processor/batchprocessor/splitter.go
@@ -1,0 +1,154 @@
+package batchprocessor
+
+import "go.opentelemetry.io/collector/consumer/pdata"
+
+func min(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
+}
+
+type traceSplitter struct {
+	splits        []pdata.Traces
+	cur           *pdata.Traces
+	limit         int
+	curSpansCount int
+}
+
+func (ts *traceSplitter) startNewBatch() {
+	ts.splits = append(ts.splits, pdata.NewTraces())
+	ts.cur = &ts.splits[len(ts.splits)-1]
+	ts.curSpansCount = 0
+}
+
+func (ts *traceSplitter) startNewBatchFromResource(oldToRs pdata.ResourceSpans) pdata.ResourceSpans {
+	ts.startNewBatch()
+
+	newToRss := ts.cur.ResourceSpans()
+	newToRss.Resize(1)
+	newToRs := newToRss.At(0)
+	oldToRs.Resource().CopyTo(newToRs.Resource())
+
+	return newToRs
+}
+
+func (ts *traceSplitter) startNewBatchFromResourceAndSpans(oldToRs pdata.ResourceSpans, oldToIls pdata.InstrumentationLibrarySpans) (pdata.ResourceSpans, pdata.InstrumentationLibrarySpans) {
+	newToRs := ts.startNewBatchFromResource(oldToRs)
+
+	newToRs.InstrumentationLibrarySpans().Resize(1)
+	oldToIls.InstrumentationLibrary().CopyTo(newToRs.InstrumentationLibrarySpans().At(0).InstrumentationLibrary())
+
+	return newToRs, newToRs.InstrumentationLibrarySpans().At(0)
+}
+
+func newTraceSplitter(limit int) *traceSplitter {
+	splits := make([]pdata.Traces, 1)
+	splits[0] = pdata.NewTraces()
+	return &traceSplitter{
+		splits:        splits,
+		cur:           &splits[0],
+		limit:         limit,
+		curSpansCount: 0,
+	}
+}
+
+func ilssSpanCount(ilss pdata.InstrumentationLibrarySpansSlice) int {
+	len := 0
+	for j := 0; j < ilss.Len(); j++ {
+		if ilss.At(j).IsNil() {
+			continue
+		}
+		len = +ilss.At(j).Spans().Len()
+	}
+	return len
+}
+
+func (ts *traceSplitter) addResourceSpansSlice(fromRss pdata.ResourceSpansSlice) {
+	for i := 0; i < fromRss.Len(); i++ {
+		fromRs := fromRss.At(i)
+		ts.addResourceSpan(fromRs)
+	}
+}
+
+func (ts *traceSplitter) addResourceSpan(fromRs pdata.ResourceSpans) {
+	fromIlss := fromRs.InstrumentationLibrarySpans()
+
+	// Start new batch if it's on the limit (TODO: do it also when it's close to the limit, to do it coarse-granularly)
+	if ts.curSpansCount >= ts.limit {
+		ts.startNewBatch()
+	}
+
+	ts.cur.ResourceSpans().Resize(ts.cur.ResourceSpans().Len() + 1)
+	toRs := ts.cur.ResourceSpans().At(ts.cur.ResourceSpans().Len() - 1)
+	fromRs.Resource().CopyTo(toRs.Resource())
+
+	if ilssSpanCount(fromIlss)+ts.curSpansCount < ts.limit {
+		ts.curSpansCount += ilssSpanCount(fromIlss)
+		fromRs.CopyTo(toRs)
+	} else {
+		ts.addInstrumentationLibrarySpansSlice(fromIlss, toRs)
+	}
+}
+
+func (ts *traceSplitter) addInstrumentationLibrarySpansSlice(fromIlss pdata.InstrumentationLibrarySpansSlice, toRs pdata.ResourceSpans) {
+	// toRs has already the resource copied, we are going reuse it if more ResourceSpans are needed
+
+	toIlss := toRs.InstrumentationLibrarySpans()
+
+	for j := 0; j < fromIlss.Len(); j++ {
+		if ts.curSpansCount >= ts.limit {
+			toRs = ts.startNewBatchFromResource(toRs)
+			toIlss = toRs.InstrumentationLibrarySpans()
+		}
+
+		fromIls := fromIlss.At(j)
+		if fromIls.IsNil() {
+			continue
+		}
+
+		// Make space for one more library spans struct
+		toIlss.Resize(toIlss.Len() + 1)
+		toIls := toIlss.At(toIlss.Len() - 1)
+
+		// Copy instrumentation library data
+		fromIls.InstrumentationLibrary().CopyTo(toIls.InstrumentationLibrary())
+
+		if fromIls.Spans().Len()+ts.curSpansCount < ts.limit {
+			ts.curSpansCount += fromIls.Spans().Len()
+			fromIls.Spans().MoveAndAppendTo(toIls.Spans())
+		} else {
+			// We might copy only limited number of spans...
+			index := 0
+			for index < fromIls.Spans().Len() {
+				if ts.curSpansCount >= ts.limit {
+					toRs, toIls = ts.startNewBatchFromResourceAndSpans(toRs, toIls)
+				}
+
+				index = ts.addSpans(fromIls, toRs, toIls, index)
+			}
+		}
+	}
+}
+
+// addSpans add specific spans up the the limit; it returns the current position of the index - if it's equal to length, everything was consumed
+func (ts *traceSplitter) addSpans(fromIls pdata.InstrumentationLibrarySpans, toRs pdata.ResourceSpans, toIls pdata.InstrumentationLibrarySpans, startIndex int) int {
+	desiredCount := min(ts.limit-ts.curSpansCount, fromIls.Spans().Len()-startIndex)
+	toIls.Spans().Resize(desiredCount)
+	fromSpanIndex := startIndex
+
+	for k := 0; k < desiredCount; k++ {
+		fromIls.Spans().At(fromSpanIndex).CopyTo(toIls.Spans().At(k))
+		fromSpanIndex += 1
+	}
+	ts.curSpansCount += desiredCount
+
+	return fromSpanIndex
+}
+
+// SplitItems takes the spans and splits then into batches of no more than limitPerBatch spans each
+func SplitItems(data pdata.Traces, limitPerBatch int) []pdata.Traces {
+	ts := newTraceSplitter(limitPerBatch)
+	ts.addResourceSpansSlice(data.ResourceSpans())
+	return ts.splits
+}

--- a/processor/batchprocessor/splitter_test.go
+++ b/processor/batchprocessor/splitter_test.go
@@ -1,0 +1,103 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package batchprocessor
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/internal/data/testdata"
+	"math"
+	"testing"
+)
+
+func testSplitCase(t *testing.T, resourceCount int, spansPerResource int, limitPerBatch int) {
+	generatedSpans := 0
+	traces := pdata.NewTraces()
+	for resourceNum := 0; resourceNum < resourceCount; resourceNum++ {
+		td := testdata.GenerateTraceDataManySpansSameResource(spansPerResource)
+		spans := td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans()
+		for resourceNumSpanIndex := 0; resourceNumSpanIndex < spansPerResource; resourceNumSpanIndex++ {
+			spans.At(resourceNumSpanIndex).SetName(getTestSpanName(resourceNum, resourceNumSpanIndex))
+		}
+		generatedSpans += spansPerResource
+		td.ResourceSpans().MoveAndAppendTo(traces.ResourceSpans())
+	}
+
+	splitTraces := SplitItems(traces, limitPerBatch)
+
+	expectedTraceSplits := int(math.Max(1, math.Ceil(float64(generatedSpans)/float64(limitPerBatch))))
+	require.Equal(t, expectedTraceSplits, len(splitTraces))
+
+	// Iterate all spans
+
+	resourceNum := 0
+	resourceNumSpanIndex := 0
+	traceIndex := 0
+	resourceIndex := 0
+	librarySpansIndex := 0
+	spanIndex := 0
+	matchedSpans := 0
+
+	for resourceNum < resourceCount {
+		td := splitTraces[traceIndex]
+		rss := td.ResourceSpans().At(resourceIndex)
+		ils := rss.InstrumentationLibrarySpans().At(librarySpansIndex)
+		if ils.Spans().Len() > 0 {
+			span := ils.Spans().At(spanIndex)
+			require.EqualValues(t, getTestSpanName(resourceNum, resourceNumSpanIndex), span.Name())
+			spanIndex++
+			matchedSpans++
+		}
+
+		if spanIndex == ils.Spans().Len() {
+			spanIndex = 0
+			librarySpansIndex++
+		}
+
+		if librarySpansIndex == rss.InstrumentationLibrarySpans().Len() {
+			librarySpansIndex = 0
+			resourceIndex++
+		}
+
+		if resourceIndex == td.ResourceSpans().Len() {
+			resourceIndex = 0
+			traceIndex++
+		}
+
+		resourceNumSpanIndex++
+		if resourceNumSpanIndex >= spansPerResource {
+			resourceNumSpanIndex = 0
+			resourceNum++
+		}
+	}
+
+	require.Equal(t, generatedSpans, matchedSpans)
+}
+
+func TestSpltting(t *testing.T) {
+	resourceCounts := []int{0, 1, 9, 10}
+	spanPerResourceCounts := []int{0, 1, 9, 10, 11, 100, 500}
+	limits := []int{1, 5, 9, 11, 50, 99, 100, 101, 102, 499, 500, 501, 999, 1000, 1001}
+
+	for _, resourceCount := range resourceCounts {
+		for _, spanPerResourceCount := range spanPerResourceCounts {
+			for _, limit := range limits {
+				fmt.Printf("Resources: %4d | Spans per resource: %4d | Limit: %4d\n", resourceCount, spanPerResourceCount, limit)
+				testSplitCase(t, resourceCount, spanPerResourceCount, limit)
+			}
+		}
+	}
+}

--- a/processor/batchprocessor/testdata/config.yaml
+++ b/processor/batchprocessor/testdata/config.yaml
@@ -6,6 +6,7 @@ processors:
   batch/2:
     timeout: 10s
     send_batch_size: 10000
+    send_batch_hard_limit: 30000
 
 exporters:
   exampleexporter:


### PR DESCRIPTION
**Description:** 

Adds a capability to set upper hard limit for batcher. 

When there are large packages sent from the client, they might be actually larger than what the vendor endpoint accepts. To solve that problem, batcher now has a capability added that breaks down larger sets of spans into smaller ones

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** Unit tests added

**Documentation:** Description of new config params