### PR TITLE
Cascading policy initial implementation

### DIFF
--- a/processor/samplingprocessor/tailsamplingprocessor/README.md
+++ b/processor/samplingprocessor/tailsamplingprocessor/README.md
@@ -16,6 +16,7 @@ Multiple policies exist today and it is straight forward to add more. These incl
 - `numeric_attribute`: Sample based on number attributes
 - `string_attribute`: Sample based on string attributes
 - `rate_limiting`: Sample based on rate
+- `cascading`: Sample based on a set of cascading rules
 
 The following configuration options can also be modified:
 - `decision_wait` (default = 30s): Wait time since the first span of a trace before making a sampling decision
@@ -50,7 +51,26 @@ processors:
             name: test-policy-4,
             type: rate_limiting,
             rate_limiting: {spans_per_second: 35}
-         }
+          },
+          {
+            name: test-policy-5,
+            type: cascading,
+
+            # This is total budget available for the policy
+            spans_per_second: 1000,
+            rules: [
+              {
+                # This rule will consume no more than 150 spans_per_second for the traces with matching spans
+                spans_per_second: 150,
+                numeric_attribute: {key: key1, min_value: 50, max_value: 100}
+              },
+              {
+                # This rule will match anything and take any left bandwidth available, up to 
+                # spans_per_second defined at the top level
+                spans_per_second: -1
+              }
+            ]
+        }
       ]
 ```
 

--- a/processor/samplingprocessor/tailsamplingprocessor/README.md
+++ b/processor/samplingprocessor/tailsamplingprocessor/README.md
@@ -17,6 +17,7 @@ Multiple policies exist today and it is straight forward to add more. These incl
 - `string_attribute`: Sample based on string attributes
 - `rate_limiting`: Sample based on rate
 - `cascading`: Sample based on a set of cascading rules
+- `duration`: Sample based on duration of trace (difference between maximum end time and minimum start time)
 
 The following configuration options can also be modified:
 - `decision_wait` (default = 30s): Wait time since the first span of a trace before making a sampling decision
@@ -61,16 +62,28 @@ processors:
             rules: [
               {
                 # This rule will consume no more than 150 spans_per_second for the traces with matching spans
+                name: "some-name",
                 spans_per_second: 150,
                 numeric_attribute: {key: key1, min_value: 50, max_value: 100}
               },
               {
+                name: "some-other-name",
+                spans_per_second: 50,
+                duration: {min_duration_micros: 9000000 }
+              },
+              {
                 # This rule will match anything and take any left bandwidth available, up to 
                 # spans_per_second defined at the top level
+                name: "capture-anything-else",
                 spans_per_second: -1
               }
             ]
-        }
+        },
+        {
+           name: test-policy-6,
+           type: duration,
+           duration: {min_duration_micros: 100000}
+        },
       ]
 ```
 

--- a/processor/samplingprocessor/tailsamplingprocessor/config/config.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/config/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tailsamplingprocessor
+package config
 
 import (
 	"time"
@@ -34,6 +34,8 @@ const (
 	StringAttribute PolicyType = "string_attribute"
 	// RateLimiting allows all traces until the specified limits are satisfied.
 	RateLimiting PolicyType = "rate_limiting"
+	// Cascading provides ability to specify several rules organized by priority an with ingestion budget
+	Cascading PolicyType = "cascading"
 )
 
 // PolicyCfg holds the common configuration to all policies.
@@ -48,6 +50,20 @@ type PolicyCfg struct {
 	StringAttributeCfg StringAttributeCfg `mapstructure:"string_attribute"`
 	// Configs for rate limiting filter sampling policy evaluator.
 	RateLimitingCfg RateLimitingCfg `mapstructure:"rate_limiting"`
+	// SpansPerSecond specifies the total budget that should never be exceeded for cascading rule
+	SpansPerSecond int64 `mapstructure:"spans_per_second"`
+	// Rules provide a list of prioritized rules for filling the budgets
+	Rules []CascadingRuleCfg `mapstructure:"rules"`
+}
+
+// CascadingRuleCfg holds specification of a given rule and its budget
+type CascadingRuleCfg struct {
+	// SpansPerSecond specifies the budget available for cascading policy rule
+	SpansPerSecond int64 `mapstructure:"spans_per_second"`
+	// Configs for numeric attribute filter sampling policy evaluator.
+	NumericAttributeCfg *NumericAttributeCfg `mapstructure:"numeric_attribute"`
+	// Configs for string attribute filter sampling policy evaluator.
+	StringAttributeCfg *StringAttributeCfg `mapstructure:"string_attribute"`
 }
 
 // NumericAttributeCfg holds the configurable settings to create a numeric attribute filter

--- a/processor/samplingprocessor/tailsamplingprocessor/config/config.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/config/config.go
@@ -34,6 +34,8 @@ const (
 	StringAttribute PolicyType = "string_attribute"
 	// RateLimiting allows all traces until the specified limits are satisfied.
 	RateLimiting PolicyType = "rate_limiting"
+	// Duration allows all traces that extend specific provided duration
+	Duration PolicyType = "duration"
 	// Cascading provides ability to specify several rules organized by priority an with ingestion budget
 	Cascading PolicyType = "cascading"
 )
@@ -50,6 +52,8 @@ type PolicyCfg struct {
 	StringAttributeCfg StringAttributeCfg `mapstructure:"string_attribute"`
 	// Configs for rate limiting filter sampling policy evaluator.
 	RateLimitingCfg RateLimitingCfg `mapstructure:"rate_limiting"`
+	// Configs for duration filter sampling policy evaluator.
+	DurationCfg DurationCfg `mapstructure:"duration"`
 	// SpansPerSecond specifies the total budget that should never be exceeded for cascading rule
 	SpansPerSecond int64 `mapstructure:"spans_per_second"`
 	// Rules provide a list of prioritized rules for filling the budgets
@@ -58,12 +62,22 @@ type PolicyCfg struct {
 
 // CascadingRuleCfg holds specification of a given rule and its budget
 type CascadingRuleCfg struct {
+	// Name, as simple as that
+	Name string `mapstructure:"name"`
 	// SpansPerSecond specifies the budget available for cascading policy rule
 	SpansPerSecond int64 `mapstructure:"spans_per_second"`
 	// Configs for numeric attribute filter sampling policy evaluator.
 	NumericAttributeCfg *NumericAttributeCfg `mapstructure:"numeric_attribute"`
 	// Configs for string attribute filter sampling policy evaluator.
 	StringAttributeCfg *StringAttributeCfg `mapstructure:"string_attribute"`
+	// Configs for duration filter sampling policy evaluator.
+	DurationCfg *DurationCfg `mapstructure:"duration"`
+}
+
+// DurationCfg holds the configurable settings to create a duration filter
+type DurationCfg struct {
+	// MinDurationMicros is the minimum duration of trace to be considered a match.
+	MinDurationMicros int64 `mapstructure:"min_duration_micros"`
 }
 
 // NumericAttributeCfg holds the configurable settings to create a numeric attribute filter

--- a/processor/samplingprocessor/tailsamplingprocessor/config_test.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/config_test.go
@@ -73,13 +73,29 @@ func TestLoadConfig(t *testing.T) {
 					SpansPerSecond: 1000,
 					Rules:     []tsconfig.CascadingRuleCfg{
 						{
+							Name: "num",
 							SpansPerSecond: 123,
 							NumericAttributeCfg: &tsconfig.NumericAttributeCfg{
 								Key: "key1", MinValue: 50, MaxValue: 100},
 						},
 						{
+							Name: "dur",
+							SpansPerSecond: 50,
+							DurationCfg: &tsconfig.DurationCfg{
+								MinDurationMicros: 9000000,
+							},
+						},
+						{
+							Name: "everything_else",
 							SpansPerSecond: -1,
 						},
+					},
+				},
+				{
+					Name:            "test-policy-6",
+					Type:            tsconfig.Duration,
+					DurationCfg: tsconfig.DurationCfg{
+						MinDurationMicros: 100000,
 					},
 				},
 			},

--- a/processor/samplingprocessor/tailsamplingprocessor/config_test.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/config_test.go
@@ -24,6 +24,7 @@ import (
 
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
+	tsconfig "go.opentelemetry.io/collector/processor/samplingprocessor/tailsamplingprocessor/config"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -38,7 +39,7 @@ func TestLoadConfig(t *testing.T) {
 	require.NotNil(t, cfg)
 
 	assert.Equal(t, cfg.Processors["tail_sampling"],
-		&Config{
+		&tsconfig.Config{
 			ProcessorSettings: configmodels.ProcessorSettings{
 				TypeVal: "tail_sampling",
 				NameVal: "tail_sampling",
@@ -46,25 +47,40 @@ func TestLoadConfig(t *testing.T) {
 			DecisionWait:            10 * time.Second,
 			NumTraces:               100,
 			ExpectedNewTracesPerSec: 10,
-			PolicyCfgs: []PolicyCfg{
+			PolicyCfgs: []tsconfig.PolicyCfg{
 				{
 					Name: "test-policy-1",
-					Type: AlwaysSample,
+					Type: tsconfig.AlwaysSample,
 				},
 				{
 					Name:                "test-policy-2",
-					Type:                NumericAttribute,
-					NumericAttributeCfg: NumericAttributeCfg{Key: "key1", MinValue: 50, MaxValue: 100},
+					Type:                tsconfig.NumericAttribute,
+					NumericAttributeCfg: tsconfig.NumericAttributeCfg{Key: "key1", MinValue: 50, MaxValue: 100},
 				},
 				{
 					Name:               "test-policy-3",
-					Type:               StringAttribute,
-					StringAttributeCfg: StringAttributeCfg{Key: "key2", Values: []string{"value1", "value2"}},
+					Type:               tsconfig.StringAttribute,
+					StringAttributeCfg: tsconfig.StringAttributeCfg{Key: "key2", Values: []string{"value1", "value2"}},
 				},
 				{
 					Name:            "test-policy-4",
-					Type:            RateLimiting,
-					RateLimitingCfg: RateLimitingCfg{SpansPerSecond: 35},
+					Type:            tsconfig.RateLimiting,
+					RateLimitingCfg: tsconfig.RateLimitingCfg{SpansPerSecond: 35},
+				},
+				{
+					Name: "test-policy-5",
+					Type: tsconfig.Cascading,
+					SpansPerSecond: 1000,
+					Rules:     []tsconfig.CascadingRuleCfg{
+						{
+							SpansPerSecond: 123,
+							NumericAttributeCfg: &tsconfig.NumericAttributeCfg{
+								Key: "key1", MinValue: 50, MaxValue: 100},
+						},
+						{
+							SpansPerSecond: -1,
+						},
+					},
 				},
 			},
 		})

--- a/processor/samplingprocessor/tailsamplingprocessor/factory.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/factory.go
@@ -15,6 +15,7 @@
 package tailsamplingprocessor
 
 import (
+	"go.opentelemetry.io/collector/processor/samplingprocessor/tailsamplingprocessor/config"
 	"time"
 
 	"go.uber.org/zap"
@@ -41,7 +42,7 @@ func (f *Factory) Type() configmodels.Type {
 
 // CreateDefaultConfig creates the default configuration for processor.
 func (f *Factory) CreateDefaultConfig() configmodels.Processor {
-	return &Config{
+	return &config.Config{
 		DecisionWait: 30 * time.Second,
 		NumTraces:    50000,
 	}
@@ -53,7 +54,7 @@ func (f *Factory) CreateTraceProcessor(
 	nextConsumer consumer.TraceConsumerOld,
 	cfg configmodels.Processor,
 ) (component.TraceProcessorOld, error) {
-	tCfg := cfg.(*Config)
+	tCfg := cfg.(*config.Config)
 	return newTraceProcessor(logger, nextConsumer, *tCfg)
 }
 

--- a/processor/samplingprocessor/tailsamplingprocessor/factory_test.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/factory_test.go
@@ -15,6 +15,7 @@
 package tailsamplingprocessor
 
 import (
+	"go.opentelemetry.io/collector/processor/samplingprocessor/tailsamplingprocessor/config"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,13 +36,13 @@ func TestCreateDefaultConfig(t *testing.T) {
 func TestCreateProcessor(t *testing.T) {
 	factory := &Factory{}
 
-	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg := factory.CreateDefaultConfig().(*config.Config)
 	// Manually set required fields
 	cfg.ExpectedNewTracesPerSec = 64
-	cfg.PolicyCfgs = []PolicyCfg{
+	cfg.PolicyCfgs = []config.PolicyCfg{
 		{
 			Name: "test-policy",
-			Type: AlwaysSample,
+			Type: config.AlwaysSample,
 		},
 	}
 

--- a/processor/samplingprocessor/tailsamplingprocessor/metrics.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/metrics.go
@@ -18,6 +18,7 @@ import (
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
+	"go.opentelemetry.io/collector/processor/samplingprocessor/tailsamplingprocessor/sampling"
 
 	"go.opentelemetry.io/collector/internal/collector/telemetry"
 	"go.opentelemetry.io/collector/obsreport"
@@ -131,6 +132,8 @@ func SamplingProcessorMetricViews(level telemetry.Level) []*view.View {
 		countTraceDroppedTooEarlyView,
 		countTraceIDArrivalView,
 		trackTracesOnMemorylView,
+
+		sampling.CountTracesSampledRulesView,
 	}
 
 	return obsreport.ProcessorMetricViews(typeStr, legacyViews)

--- a/processor/samplingprocessor/tailsamplingprocessor/processor.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/processor.go
@@ -133,7 +133,9 @@ func getPolicyEvaluator(logger *zap.Logger, cfg *config.PolicyCfg) (sampling.Pol
 		rlfCfg := cfg.RateLimitingCfg
 		return sampling.NewRateLimiting(logger, rlfCfg.SpansPerSecond), nil
 	case config.Cascading:
-		return sampling.NewCascadingFilter(logger, cfg), nil
+		return sampling.NewCascadingFilter(logger, cfg)
+	case config.Duration:
+		return sampling.NewDurationFilter(logger, cfg.DurationCfg.MinDurationMicros), nil
 	default:
 		return nil, fmt.Errorf("unknown sampling policy type %s", cfg.Type)
 	}

--- a/processor/samplingprocessor/tailsamplingprocessor/sampling/always_sample.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/sampling/always_sample.go
@@ -41,6 +41,11 @@ func (as *alwaysSample) OnLateArrivingSpans(earlyDecision Decision, spans []*tra
 	return nil
 }
 
+// EvaluateSecondChance looks at the trace again and if it can/cannot be fit, returns a SamplingDecision
+func (as *alwaysSample) EvaluateSecondChance(traceID []byte, trace *TraceData) (Decision, error) {
+	return NotSampled, nil
+}
+
 // Evaluate looks at the trace data and returns a corresponding SamplingDecision.
 func (as *alwaysSample) Evaluate(traceID []byte, trace *TraceData) (Decision, error) {
 	as.logger.Debug("Evaluating spans in always-sample filter")

--- a/processor/samplingprocessor/tailsamplingprocessor/sampling/cascading.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/sampling/cascading.go
@@ -1,0 +1,192 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling
+
+import (
+	"time"
+
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/processor/samplingprocessor/tailsamplingprocessor/config"
+)
+
+type cascadingPolicy struct {
+	logger *zap.Logger
+
+	currentSecond        int64
+	maxSpansPerSecond int64
+	spansInCurrentSecond int64
+
+	rules []cascadingRuleEvaluation
+}
+
+type cascadingRuleEvaluation struct {
+	// In fact, this can be only NumericTagFilter, StringTagFilter or AlwaysSample
+	evaluator PolicyEvaluator
+
+	currentSecond        int64
+	// Set maxSpansPerSecond to zero to make it opportunistic rule (it will fill
+	// only if there's space after evaluating other ones)
+	maxSpansPerSecond    int64
+	spansInCurrentSecond int64
+}
+
+func (cp cascadingPolicy) shouldConsider(currSecond int64, trace *TraceData) bool {
+	if trace.SpanCount > cp.maxSpansPerSecond {
+		// This trace will never fit
+		return false
+	} else if cp.currentSecond == currSecond && trace.SpanCount > cp.maxSpansPerSecond - cp.spansInCurrentSecond {
+		// This trace will not fit in this second, no way
+		return false
+	} else {
+		return true
+	}
+}
+
+func (cp cascadingPolicy) updateRate(currSecond int64, numSpans int64) Decision {
+	if cp.currentSecond != currSecond {
+		cp.currentSecond = currSecond
+		cp.spansInCurrentSecond = 0
+	}
+
+	spansInSecondIfSampled := cp.spansInCurrentSecond + numSpans
+	if spansInSecondIfSampled < cp.maxSpansPerSecond {
+		cp.spansInCurrentSecond = spansInSecondIfSampled
+		return Sampled
+	}
+
+	return NotSampled
+}
+
+
+func (cre *cascadingRuleEvaluation) shouldConsider(currSecond int64, cp *cascadingPolicy, trace *TraceData) bool {
+	if cre.maxSpansPerSecond < 0 {
+		return true // opportunistic rule
+	} else if trace.SpanCount > cre.maxSpansPerSecond {
+		// This trace will never fit
+		return false
+	} else if cp.currentSecond == currSecond && trace.SpanCount > cre.maxSpansPerSecond-cre.spansInCurrentSecond {
+		// This trace will not fit in this second
+		return false
+	} else {
+		return true
+	}
+}
+
+func (cre *cascadingRuleEvaluation) updateRate(currSecond int64, trace *TraceData) Decision {
+	if cre.currentSecond != currSecond {
+		cre.currentSecond = currSecond
+		cre.spansInCurrentSecond = 0
+	}
+
+	spansInSecondIfSampled := cre.spansInCurrentSecond + trace.SpanCount
+	if spansInSecondIfSampled < cre.maxSpansPerSecond {
+		cre.spansInCurrentSecond = spansInSecondIfSampled
+		return Sampled
+	}
+
+	return NotSampled
+}
+
+var _ PolicyEvaluator = (*cascadingPolicy)(nil)
+
+// NewNumericAttributeFilter creates a cascading policy evaluator
+func NewCascadingFilter(logger *zap.Logger, cfg *config.PolicyCfg) PolicyEvaluator {
+	cascadingRules := make([]cascadingRuleEvaluation, 0)
+
+	for _, ruleCfg := range cfg.Rules {
+		if ruleCfg.StringAttributeCfg != nil && ruleCfg.NumericAttributeCfg != nil {
+			logger.Error("Cascading policy cannot have both string and numeric attributes at the same time")
+			// TODO: proper error handling
+		}
+
+		evaluator := NewAlwaysSample(logger)
+
+		if ruleCfg.StringAttributeCfg != nil {
+			evaluator = NewStringAttributeFilter(logger, ruleCfg.StringAttributeCfg.Key, ruleCfg.StringAttributeCfg.Values)
+		} else if ruleCfg.NumericAttributeCfg != nil {
+			evaluator = NewNumericAttributeFilter(logger,
+				ruleCfg.NumericAttributeCfg.Key,
+				ruleCfg.NumericAttributeCfg.MinValue,
+				ruleCfg.NumericAttributeCfg.MaxValue)
+		}
+
+		cascadingRules = append(cascadingRules, cascadingRuleEvaluation{
+			evaluator:         evaluator,
+			maxSpansPerSecond: ruleCfg.SpansPerSecond,
+		})
+	}
+
+	return &cascadingPolicy{
+		logger:            logger,
+		maxSpansPerSecond: cfg.SpansPerSecond,
+		rules:             cascadingRules,
+	}
+}
+
+// OnLateArrivingSpans notifies the evaluator that the given list of spans arrived
+// after the sampling decision was already taken for the trace.
+// This gives the evaluator a chance to log any message/metrics and/or update any
+// related internal state.
+func (cp *cascadingPolicy) OnLateArrivingSpans(earlyDecision Decision, spans []*tracepb.Span) error {
+	if earlyDecision == Sampled {
+		// Update the current rate, this event means that spans were sampled nevertheless due to previous decision
+		cp.updateRate(time.Now().Unix(), int64(len(spans)))
+	}
+	cp.logger.Debug("Triggering action for late arriving spans in cascading filter")
+	return nil
+}
+
+// Evaluate looks at the trace data and returns a corresponding SamplingDecision.
+func (cp *cascadingPolicy) Evaluate(traceID []byte, trace *TraceData) (Decision, error) {
+	cp.logger.Debug("Evaluating spans in cascading filter")
+
+	currSecond := time.Now().Unix()
+
+	if !cp.shouldConsider(currSecond, trace) {
+		return NotSampled, nil
+	}
+
+	for _, rule := range cp.rules {
+		if rule.maxSpansPerSecond < 0 {
+			if ruleDecision, err := rule.evaluator.Evaluate(traceID, trace); err != nil && ruleDecision == Sampled {
+				return SecondChance, nil
+			}
+		} else if rule.shouldConsider(currSecond, cp, trace) {
+			if ruleDecision, err := rule.evaluator.Evaluate(traceID, trace); err != nil && ruleDecision == Sampled {
+				if rule.updateRate(currSecond, trace) == Sampled {
+					policyDecision := cp.updateRate(currSecond, trace.SpanCount)
+					return policyDecision, nil
+				}
+			}
+		}
+	}
+
+	return NotSampled, nil
+}
+
+// EvaluateSecondChance looks if more traces can be fit after initial decisions was made
+func (cp *cascadingPolicy) EvaluateSecondChance(traceID []byte, trace *TraceData) (Decision, error) {
+	// Lets keep it evaluated for the current batch second
+	return cp.updateRate(cp.currentSecond, trace.SpanCount), nil
+}
+
+// OnDroppedSpans is called when the trace needs to be dropped, due to memory
+// pressure, before the decision_wait time has been reached.
+func (cp *cascadingPolicy) OnDroppedSpans(traceID []byte, trace *TraceData) (Decision, error) {
+	cp.logger.Debug("Triggering action for dropped spans in cascading filter")
+	return NotSampled, nil
+}

--- a/processor/samplingprocessor/tailsamplingprocessor/sampling/cascading.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/sampling/cascading.go
@@ -15,6 +15,11 @@
 package sampling
 
 import (
+	"context"
+	"errors"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
 	"time"
 
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
@@ -27,28 +32,47 @@ type cascadingPolicy struct {
 	logger *zap.Logger
 
 	currentSecond        int64
-	maxSpansPerSecond int64
+	maxSpansPerSecond    int64
 	spansInCurrentSecond int64
 
-	rules []cascadingRuleEvaluation
+	rules []*cascadingRuleEvaluation
 }
 
 type cascadingRuleEvaluation struct {
-	// In fact, this can be only NumericTagFilter, StringTagFilter or AlwaysSample
+	// In fact, this can be only NumericTagFilter, StringTagFilter, Duration or AlwaysSample
 	evaluator PolicyEvaluator
 
-	currentSecond        int64
+	context context.Context
+
+	currentSecond int64
 	// Set maxSpansPerSecond to zero to make it opportunistic rule (it will fill
 	// only if there's space after evaluating other ones)
 	maxSpansPerSecond    int64
 	spansInCurrentSecond int64
 }
 
-func (cp cascadingPolicy) shouldConsider(currSecond int64, trace *TraceData) bool {
+var (
+	tagRuleKey, _       = tag.NewKey("rule")
+	tagSampledKey, _    = tag.NewKey("sampled")
+	tagConsideredKey, _ = tag.NewKey("considered")
+
+	statCascadingTracesSampled = stats.Int64("count_cascading_traces_sampled", "Count of traces that were sampled or not", stats.UnitDimensionless)
+
+	sampledTagKeys              = []tag.Key{tagRuleKey, tagConsideredKey, tagSampledKey}
+	CountTracesSampledRulesView = &view.View{
+		Name:        statCascadingTracesSampled.Name(),
+		Measure:     statCascadingTracesSampled,
+		Description: statCascadingTracesSampled.Description(),
+		TagKeys:     sampledTagKeys,
+		Aggregation: view.Sum(),
+	}
+)
+
+func (cp *cascadingPolicy) shouldConsider(currSecond int64, trace *TraceData) bool {
 	if trace.SpanCount > cp.maxSpansPerSecond {
 		// This trace will never fit
 		return false
-	} else if cp.currentSecond == currSecond && trace.SpanCount > cp.maxSpansPerSecond - cp.spansInCurrentSecond {
+	} else if cp.currentSecond == currSecond && trace.SpanCount > cp.maxSpansPerSecond-cp.spansInCurrentSecond {
 		// This trace will not fit in this second, no way
 		return false
 	} else {
@@ -56,34 +80,19 @@ func (cp cascadingPolicy) shouldConsider(currSecond int64, trace *TraceData) boo
 	}
 }
 
-func (cp cascadingPolicy) updateRate(currSecond int64, numSpans int64) Decision {
+func (cp *cascadingPolicy) updateRate(currSecond int64, numSpans int64) Decision {
 	if cp.currentSecond != currSecond {
 		cp.currentSecond = currSecond
 		cp.spansInCurrentSecond = 0
 	}
 
 	spansInSecondIfSampled := cp.spansInCurrentSecond + numSpans
-	if spansInSecondIfSampled < cp.maxSpansPerSecond {
+	if spansInSecondIfSampled <= cp.maxSpansPerSecond {
 		cp.spansInCurrentSecond = spansInSecondIfSampled
 		return Sampled
 	}
 
 	return NotSampled
-}
-
-
-func (cre *cascadingRuleEvaluation) shouldConsider(currSecond int64, cp *cascadingPolicy, trace *TraceData) bool {
-	if cre.maxSpansPerSecond < 0 {
-		return true // opportunistic rule
-	} else if trace.SpanCount > cre.maxSpansPerSecond {
-		// This trace will never fit
-		return false
-	} else if cp.currentSecond == currSecond && trace.SpanCount > cre.maxSpansPerSecond-cre.spansInCurrentSecond {
-		// This trace will not fit in this second
-		return false
-	} else {
-		return true
-	}
 }
 
 func (cre *cascadingRuleEvaluation) updateRate(currSecond int64, trace *TraceData) Decision {
@@ -93,7 +102,7 @@ func (cre *cascadingRuleEvaluation) updateRate(currSecond int64, trace *TraceDat
 	}
 
 	spansInSecondIfSampled := cre.spansInCurrentSecond + trace.SpanCount
-	if spansInSecondIfSampled < cre.maxSpansPerSecond {
+	if spansInSecondIfSampled <= cre.maxSpansPerSecond {
 		cre.spansInCurrentSecond = spansInSecondIfSampled
 		return Sampled
 	}
@@ -104,13 +113,23 @@ func (cre *cascadingRuleEvaluation) updateRate(currSecond int64, trace *TraceDat
 var _ PolicyEvaluator = (*cascadingPolicy)(nil)
 
 // NewNumericAttributeFilter creates a cascading policy evaluator
-func NewCascadingFilter(logger *zap.Logger, cfg *config.PolicyCfg) PolicyEvaluator {
-	cascadingRules := make([]cascadingRuleEvaluation, 0)
+func NewCascadingFilter(logger *zap.Logger, cfg *config.PolicyCfg) (PolicyEvaluator, error) {
+	cascadingRules := make([]*cascadingRuleEvaluation, 0)
 
 	for _, ruleCfg := range cfg.Rules {
-		if ruleCfg.StringAttributeCfg != nil && ruleCfg.NumericAttributeCfg != nil {
-			logger.Error("Cascading policy cannot have both string and numeric attributes at the same time")
-			// TODO: proper error handling
+		attributesSet := 0
+		if ruleCfg.StringAttributeCfg != nil {
+			attributesSet += 1
+		}
+		if ruleCfg.NumericAttributeCfg != nil {
+			attributesSet += 1
+		}
+		if ruleCfg.DurationCfg != nil {
+			attributesSet += 1
+		}
+
+		if attributesSet > 1 {
+			return nil, errors.New("cascading policy can have at most one filter set per rule")
 		}
 
 		evaluator := NewAlwaysSample(logger)
@@ -122,10 +141,15 @@ func NewCascadingFilter(logger *zap.Logger, cfg *config.PolicyCfg) PolicyEvaluat
 				ruleCfg.NumericAttributeCfg.Key,
 				ruleCfg.NumericAttributeCfg.MinValue,
 				ruleCfg.NumericAttributeCfg.MaxValue)
+		} else if ruleCfg.DurationCfg != nil {
+			evaluator = NewDurationFilter(logger, ruleCfg.DurationCfg.MinDurationMicros)
 		}
 
-		cascadingRules = append(cascadingRules, cascadingRuleEvaluation{
+		ctx, _ := tag.New(context.Background(), tag.Upsert(tagRuleKey, ruleCfg.Name))
+
+		cascadingRules = append(cascadingRules, &cascadingRuleEvaluation{
 			evaluator:         evaluator,
+			context:           ctx,
 			maxSpansPerSecond: ruleCfg.SpansPerSecond,
 		})
 	}
@@ -134,7 +158,7 @@ func NewCascadingFilter(logger *zap.Logger, cfg *config.PolicyCfg) PolicyEvaluat
 		logger:            logger,
 		maxSpansPerSecond: cfg.SpansPerSecond,
 		rules:             cascadingRules,
-	}
+	}, nil
 }
 
 // OnLateArrivingSpans notifies the evaluator that the given list of spans arrived
@@ -162,26 +186,62 @@ func (cp *cascadingPolicy) Evaluate(traceID []byte, trace *TraceData) (Decision,
 
 	for _, rule := range cp.rules {
 		if rule.maxSpansPerSecond < 0 {
-			if ruleDecision, err := rule.evaluator.Evaluate(traceID, trace); err != nil && ruleDecision == Sampled {
+			if ruleDecision, err := rule.evaluator.Evaluate(traceID, trace); err == nil && ruleDecision == Sampled {
+				recordSampled(rule.context, "second_chance", SecondChance)
 				return SecondChance, nil
 			}
-		} else if rule.shouldConsider(currSecond, cp, trace) {
-			if ruleDecision, err := rule.evaluator.Evaluate(traceID, trace); err != nil && ruleDecision == Sampled {
+			recordSampled(rule.context, "second_chance", NotSampled)
+		} else {
+			if ruleDecision, err := rule.evaluator.Evaluate(traceID, trace); err == nil && ruleDecision == Sampled {
+				// If it's here, then the criteria for the rule fit
+
 				if rule.updateRate(currSecond, trace) == Sampled {
+					// If it's here, then the trace made it into the sampled pool
+
+					// This step is a sanity check (which might sample out the trace when
+					// sampling is misconfigured or when some late spans from previous
+					// decision got in already)
 					policyDecision := cp.updateRate(currSecond, trace.SpanCount)
+					recordSampled(rule.context, "matched", policyDecision)
 					return policyDecision, nil
 				}
+
+				// This will ensure it's not sampled (otherwise it would get into SecondChance)
+				// This behaviour might be worth giving a deeper thought, as it effective removes matching
+				// traces from the SecondChance pool.
+				recordSampled(rule.context, "matched", NotSampled)
+				return NotSampled, nil
+
 			}
+			recordSampled(rule.context, "not-matched", NotSampled)
 		}
 	}
 
 	return NotSampled, nil
 }
 
+func recordSampled(ctx context.Context, consideredKey string, decision Decision) {
+	decisionStr := "false"
+	if decision == Sampled {
+		decisionStr = "true"
+	} else if decision == SecondChance {
+		decisionStr = "second_chance"
+	}
+
+	stats.RecordWithTags(
+		ctx,
+		[]tag.Mutator{tag.Insert(tagConsideredKey, consideredKey), tag.Insert(tagSampledKey, decisionStr)},
+		statCascadingTracesSampled.M(int64(1)),
+	)
+
+}
+
 // EvaluateSecondChance looks if more traces can be fit after initial decisions was made
 func (cp *cascadingPolicy) EvaluateSecondChance(traceID []byte, trace *TraceData) (Decision, error) {
 	// Lets keep it evaluated for the current batch second
-	return cp.updateRate(cp.currentSecond, trace.SpanCount), nil
+	sampled := cp.updateRate(cp.currentSecond, trace.SpanCount)
+	recordSampled(context.Background(), "second_chance", sampled)
+	return sampled, nil
 }
 
 // OnDroppedSpans is called when the trace needs to be dropped, due to memory

--- a/processor/samplingprocessor/tailsamplingprocessor/sampling/cascading_test.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/sampling/cascading_test.go
@@ -1,0 +1,134 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/consumer/consumerdata"
+	tsconfig "go.opentelemetry.io/collector/processor/samplingprocessor/tailsamplingprocessor/config"
+)
+
+func createSpan(durationMicros int64) tracepb.Span {
+	nowTs := time.Now().Unix()
+	startTime := timestamp.Timestamp{
+		Seconds: nowTs - durationMicros/1000000,
+		Nanos:   0,
+	}
+	endTime := timestamp.Timestamp{
+		Seconds: nowTs,
+		Nanos:   0,
+	}
+
+	return tracepb.Span{
+		Attributes: &tracepb.Span_Attributes{
+			AttributeMap: map[string]*tracepb.AttributeValue{
+				"foo": {Value: &tracepb.AttributeValue_IntValue{IntValue: 55}},
+			},
+		},
+		StartTime: &startTime,
+		EndTime:   &endTime,
+	}
+}
+
+func createTrace(numSpans int, durationMicros int64) *TraceData {
+	var spans []*tracepb.Span
+
+	for i := 0; i < numSpans; i++ {
+		span := createSpan(durationMicros)
+		spans = append(spans, &span)
+	}
+
+	return &TraceData{
+		Mutex:        sync.Mutex{},
+		Decisions:    nil,
+		ArrivalTime:  time.Time{},
+		DecisionTime: time.Time{},
+		SpanCount:    int64(numSpans),
+		ReceivedBatches: []consumerdata.TraceData{{
+			Spans: spans,
+		}},
+	}
+}
+
+func createCascadingEvaluator() PolicyEvaluator {
+	config := tsconfig.PolicyCfg{
+		Name:           "test-policy-5",
+		Type:           tsconfig.Cascading,
+		SpansPerSecond: 1000,
+		Rules: []tsconfig.CascadingRuleCfg{
+			{
+				Name:           "duration",
+				SpansPerSecond: 10,
+				DurationCfg: &tsconfig.DurationCfg{
+					MinDurationMicros: 10000,
+				},
+			},
+			{
+				Name:           "everything_else",
+				SpansPerSecond: -1,
+			},
+		},
+	}
+
+	cascading, _ := NewCascadingFilter(zap.NewNop(), &config)
+	return cascading
+}
+
+func TestSampling(t *testing.T) {
+	cascading := createCascadingEvaluator()
+
+	decision, _ := cascading.Evaluate([]byte{0}, createTrace(8, 1000000))
+	require.Equal(t, Sampled, decision)
+
+	decision, _ = cascading.Evaluate([]byte{1}, createTrace(8, 1000000))
+	require.Equal(t, NotSampled, decision)
+}
+
+func TestSecondChanceEvaluation(t *testing.T) {
+	cascading := createCascadingEvaluator()
+
+	decision, _ := cascading.Evaluate([]byte{0}, createTrace(8, 1000))
+	require.Equal(t, SecondChance, decision)
+
+	decision, _ = cascading.Evaluate([]byte{1}, createTrace(8, 1000))
+	require.Equal(t, SecondChance, decision)
+
+	// This would never fit anyway
+	decision, _ = cascading.Evaluate([]byte{1}, createTrace(8000, 1000))
+	require.Equal(t, NotSampled, decision)
+}
+
+func TestSecondChanceReevaluation(t *testing.T) {
+	cascading := createCascadingEvaluator()
+
+	decision, _ := cascading.EvaluateSecondChance([]byte{1}, createTrace(100, 1000))
+	require.Equal(t, Sampled, decision)
+
+	// Too much
+	decision, _ = cascading.EvaluateSecondChance([]byte{1}, createTrace(1000, 1000))
+	require.Equal(t, NotSampled, decision)
+
+	// Just right
+	decision, _ = cascading.EvaluateSecondChance([]byte{1}, createTrace(900, 1000))
+	require.Equal(t, Sampled, decision)
+}

--- a/processor/samplingprocessor/tailsamplingprocessor/sampling/duration_filter.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/sampling/duration_filter.go
@@ -1,0 +1,98 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling
+
+import (
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/golang/protobuf/ptypes/timestamp"
+	"go.uber.org/zap"
+)
+
+type durationFilter struct {
+	minDurationMicros int64
+	logger            *zap.Logger
+}
+
+var _ PolicyEvaluator = (*durationFilter)(nil)
+
+// NewDurationFilter creates a policy evaluator that samples all traces with
+// the duration exceeding min duration
+func NewDurationFilter(logger *zap.Logger, minDurationMicros int64) PolicyEvaluator {
+	return &durationFilter{
+		minDurationMicros: minDurationMicros,
+		logger:            logger,
+	}
+}
+
+// OnLateArrivingSpans notifies the evaluator that the given list of spans arrived
+// after the sampling decision was already taken for the trace.
+// This gives the evaluator a chance to log any message/metrics and/or update any
+// related internal state.
+func (df *durationFilter) OnLateArrivingSpans(earlyDecision Decision, spans []*tracepb.Span) error {
+	return nil
+}
+
+// EvaluateSecondChance looks at the trace again and if it can/cannot be fit, returns a SamplingDecision
+func (df *durationFilter) EvaluateSecondChance(traceID []byte, trace *TraceData) (Decision, error) {
+	return NotSampled, nil
+}
+
+func tsToMicros(ts *timestamp.Timestamp) int64 {
+	return ts.Seconds*1000000 + int64(ts.Nanos/1000)
+}
+
+// Evaluate looks at the trace data and returns a corresponding SamplingDecision.
+func (df *durationFilter) Evaluate(traceID []byte, trace *TraceData) (Decision, error) {
+	trace.Lock()
+	batches := trace.ReceivedBatches
+	trace.Unlock()
+
+	minStartTime := int64(0)
+	maxEndTime := int64(0)
+	for _, batch := range batches {
+		for _, span := range batch.Spans {
+			if span == nil {
+				continue
+			}
+			startTs := tsToMicros(span.StartTime)
+			endTs := tsToMicros(span.EndTime)
+
+			if minStartTime == 0 {
+				minStartTime = startTs
+				maxEndTime = endTs
+			} else {
+				if startTs < minStartTime {
+					minStartTime = startTs
+				}
+				if endTs > maxEndTime {
+					maxEndTime = endTs
+				}
+			}
+		}
+	}
+
+	// Sanity check first
+	if maxEndTime > minStartTime && maxEndTime-minStartTime >= df.minDurationMicros {
+		return Sampled, nil
+	}
+
+	return NotSampled, nil
+}
+
+// OnDroppedSpans is called when the trace needs to be dropped, due to memory
+// pressure, before the decision_wait time has been reached.
+func (df *durationFilter) OnDroppedSpans(traceID []byte, trace *TraceData) (Decision, error) {
+	return NotSampled, nil
+}

--- a/processor/samplingprocessor/tailsamplingprocessor/sampling/numeric_tag_filter.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/sampling/numeric_tag_filter.go
@@ -47,6 +47,11 @@ func (naf *numericAttributeFilter) OnLateArrivingSpans(earlyDecision Decision, s
 	return nil
 }
 
+// EvaluateSecondChance looks at the trace again and if it can/cannot be fit, returns a SamplingDecision
+func (naf *numericAttributeFilter) EvaluateSecondChance(traceID []byte, trace *TraceData) (Decision, error) {
+	return NotSampled, nil
+}
+
 // Evaluate looks at the trace data and returns a corresponding SamplingDecision.
 func (naf *numericAttributeFilter) Evaluate(traceID []byte, trace *TraceData) (Decision, error) {
 	naf.logger.Debug("Evaluating spans in numeric-attribute filter")

--- a/processor/samplingprocessor/tailsamplingprocessor/sampling/policy.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/sampling/policy.go
@@ -49,6 +49,9 @@ const (
 	// Sampled is used to indicate that the decision was already taken
 	// to sample the data.
 	Sampled
+	// SecondChance is a special category that allows to make a final decision
+	// after all batches are processed. It should be converted to Sampled or NotSampled
+	SecondChance
 	// NotSampled is used to indicate that the decision was already taken
 	// to not sample the data.
 	NotSampled
@@ -68,6 +71,9 @@ type PolicyEvaluator interface {
 
 	// Evaluate looks at the trace data and returns a corresponding SamplingDecision.
 	Evaluate(traceID []byte, trace *TraceData) (Decision, error)
+
+	// EvaluateSecondChance looks at the trace again and if it can/cannot be fit, returns a SamplingDecision
+	EvaluateSecondChance(traceID []byte, trace *TraceData) (Decision, error)
 
 	// OnDroppedSpans is called when the trace needs to be dropped, due to memory
 	// pressure, before the decision_wait time has been reached.

--- a/processor/samplingprocessor/tailsamplingprocessor/sampling/rate_limiting.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/sampling/rate_limiting.go
@@ -47,6 +47,11 @@ func (r *rateLimiting) OnLateArrivingSpans(earlyDecision Decision, spans []*trac
 	return nil
 }
 
+// EvaluateSecondChance looks at the trace again and if it can/cannot be fit, returns a SamplingDecision
+func (r *rateLimiting) EvaluateSecondChance(traceID []byte, trace *TraceData) (Decision, error) {
+	return NotSampled, nil
+}
+
 // Evaluate looks at the trace data and returns a corresponding SamplingDecision.
 func (r *rateLimiting) Evaluate(traceID []byte, trace *TraceData) (Decision, error) {
 	r.logger.Debug("Evaluating spans in rate-limiting filter")

--- a/processor/samplingprocessor/tailsamplingprocessor/sampling/string_tag_filter.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/sampling/string_tag_filter.go
@@ -52,6 +52,11 @@ func (saf *stringAttributeFilter) OnLateArrivingSpans(earlyDecision Decision, sp
 	return nil
 }
 
+// EvaluateSecondChance looks at the trace again and if it can/cannot be fit, returns a SamplingDecision
+func (saf *stringAttributeFilter) EvaluateSecondChance(traceID []byte, trace *TraceData) (Decision, error) {
+	return NotSampled, nil
+}
+
 // Evaluate looks at the trace data and returns a corresponding SamplingDecision.
 func (saf *stringAttributeFilter) Evaluate(traceID []byte, trace *TraceData) (Decision, error) {
 	saf.logger.Debug("Evaluting spans in string-tag filter")

--- a/processor/samplingprocessor/tailsamplingprocessor/testdata/tail_sampling_config.yaml
+++ b/processor/samplingprocessor/tailsamplingprocessor/testdata/tail_sampling_config.yaml
@@ -36,14 +36,26 @@ processors:
             spans_per_second: 1000,
             rules: [
               {
+                name: "num",
                 spans_per_second: 123,
                 numeric_attribute: {key: key1, min_value: 50, max_value: 100}
               },
               {
+                name: "dur",
+                spans_per_second: 50,
+                duration: {min_duration_micros: 9000000 }
+              },
+              {
+                name: "everything_else",
                 spans_per_second: -1
               }
             ]
-         }
+         },
+         {
+            name: test-policy-6,
+            type: duration,
+            duration: {min_duration_micros: 100000}
+         },
       ]
 
 service:

--- a/processor/samplingprocessor/tailsamplingprocessor/testdata/tail_sampling_config.yaml
+++ b/processor/samplingprocessor/tailsamplingprocessor/testdata/tail_sampling_config.yaml
@@ -29,6 +29,20 @@ processors:
             name: test-policy-4,
             type: rate_limiting,
             rate_limiting: {spans_per_second: 35}
+          },
+          {
+            name: test-policy-5,
+            type: cascading,
+            spans_per_second: 1000,
+            rules: [
+              {
+                spans_per_second: 123,
+                numeric_attribute: {key: key1, min_value: 50, max_value: 100}
+              },
+              {
+                spans_per_second: -1
+              }
+            ]
          }
       ]
 


### PR DESCRIPTION
**Description:** 

This is initial work on cascading policy implementation, where several rules can be applied with separate sampling rates. A refactoring will most likely follow to unify the other policy behaviours

There's a top level max rate of spans per second and separate rates for each of the rules. Additionally, some rules can specify the max span rate as `-1`, which means that whatever bandwidth is available can be accommodated by them, after all traces are evaluated.

For example, if there's a set of rules that specify following:

```
            spans_per_second: 300,
            rules: [
              {
                spans_per_second: 150,
                numeric_attribute: {key: key1, min_value: 50, max_value: 100}
              },
              {
                spans_per_second: -1
              }
            ]
```

Then traces with total up to 150 spans matching `key1 between 50 and 100` will be sampled and the remainder will be available for all traces.

Lets say that we have following traces:

* `Trace A` with 100 spans, with one of them having `key1=70`
* `Trace B` with 100 spans, with one of them having `key1=80`
* `Trace C` with 100 spans, neither having matching `key1` attribute
* `Trace D` with 100 spans, neither having matching `key1` attribute
* `Trace E` with 100 spans, neither having matching `key1` attribute

In such case, the processor might yield following traces:
* `Trace A` (for the rule specified)
* `Trace C`
* `Trace D`

`Trace B` would be skipped because there's not enough bandwidth available for the rule. `Trace C` and `Trace D` would be selected because they could fit the remaining 200 spans.

**Link to tracking Issue:** N/A

**Testing:** Unit test for cascading policy added. Manual tests of solution done

**Documentation:** Example addded