### PR TITLE
Convert duration filter into properties filter

### DIFF
--- a/processor/samplingprocessor/tailsamplingprocessor/README.md
+++ b/processor/samplingprocessor/tailsamplingprocessor/README.md
@@ -17,7 +17,7 @@ Multiple policies exist today and it is straight forward to add more. These incl
 - `string_attribute`: Sample based on string attributes
 - `rate_limiting`: Sample based on rate
 - `cascading`: Sample based on a set of cascading rules
-- `duration`: Sample based on duration of trace (difference between maximum end time and minimum start time)
+- `properties`: Sample based on properties (duration, operation name, number of spans) 
 
 The following configuration options can also be modified:
 - `decision_wait` (default = 30s): Wait time since the first span of a trace before making a sampling decision
@@ -69,7 +69,7 @@ processors:
               {
                 name: "some-other-name",
                 spans_per_second: 50,
-                duration: {min_duration_micros: 9000000 }
+                properties: {min_duration_micros: 9000000 }
               },
               {
                 # This rule will match anything and take any left bandwidth available, up to 
@@ -81,8 +81,12 @@ processors:
         },
         {
            name: test-policy-6,
-           type: duration,
-           duration: {min_duration_micros: 100000}
+           type: properties,
+           properties: {
+              name_pattern: "foo.*",
+              min_number_of_spans: 10,
+              min_duration_micros: 100000
+           }
         },
       ]
 ```

--- a/processor/samplingprocessor/tailsamplingprocessor/config/config.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/config/config.go
@@ -34,8 +34,8 @@ const (
 	StringAttribute PolicyType = "string_attribute"
 	// RateLimiting allows all traces until the specified limits are satisfied.
 	RateLimiting PolicyType = "rate_limiting"
-	// Duration allows all traces that extend specific provided duration
-	Duration PolicyType = "duration"
+	// Properties allows all traces that conform to specified properties.
+	Properties PolicyType = "properties"
 	// Cascading provides ability to specify several rules organized by priority an with ingestion budget
 	Cascading PolicyType = "cascading"
 )
@@ -52,8 +52,8 @@ type PolicyCfg struct {
 	StringAttributeCfg StringAttributeCfg `mapstructure:"string_attribute"`
 	// Configs for rate limiting filter sampling policy evaluator.
 	RateLimitingCfg RateLimitingCfg `mapstructure:"rate_limiting"`
-	// Configs for duration filter sampling policy evaluator.
-	DurationCfg DurationCfg `mapstructure:"duration"`
+	// Configs for properties sampling policy evaluator.
+	PropertiesCfg PropertiesCfg `mapstructure:"properties"`
 	// SpansPerSecond specifies the total budget that should never be exceeded for cascading rule
 	SpansPerSecond int64 `mapstructure:"spans_per_second"`
 	// Rules provide a list of prioritized rules for filling the budgets
@@ -70,14 +70,18 @@ type CascadingRuleCfg struct {
 	NumericAttributeCfg *NumericAttributeCfg `mapstructure:"numeric_attribute"`
 	// Configs for string attribute filter sampling policy evaluator.
 	StringAttributeCfg *StringAttributeCfg `mapstructure:"string_attribute"`
-	// Configs for duration filter sampling policy evaluator.
-	DurationCfg *DurationCfg `mapstructure:"duration"`
+	// Configs for properties sampling policy evaluator.
+	PropertiesCfg *PropertiesCfg `mapstructure:"properties"`
 }
 
-// DurationCfg holds the configurable settings to create a duration filter
-type DurationCfg struct {
-	// MinDurationMicros is the minimum duration of trace to be considered a match.
-	MinDurationMicros int64 `mapstructure:"min_duration_micros"`
+// PropertiesCfg holds the configurable settings to create a duration filter
+type PropertiesCfg struct {
+	// NamePattern (optional) describes a regular expression that must be met by any span operation name.
+	NamePattern *string `mapstructure:"name_pattern"`
+	// MinDurationMicros (optional) is the minimum duration of trace to be considered a match.
+	MinDurationMicros *int64 `mapstructure:"min_duration_micros"`
+	// MinNumberOfSpans (optional) is the minimum number spans that must be present in a matching trace.
+	MinNumberOfSpans *int `mapstructure:"min_number_of_spans"`
 }
 
 // NumericAttributeCfg holds the configurable settings to create a numeric attribute filter

--- a/processor/samplingprocessor/tailsamplingprocessor/config_test.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/config_test.go
@@ -39,6 +39,10 @@ func TestLoadConfig(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, cfg)
 
+	minDurationValue := int64(9000000)
+	minSpansValue := 10
+	namePatternValue := "foo.*"
+
 	assert.Equal(t, cfg.Processors["tail_sampling"],
 		&config.Config{
 			ProcessorSettings: configmodels.ProcessorSettings{
@@ -82,8 +86,8 @@ func TestLoadConfig(t *testing.T) {
 						{
 							Name: "dur",
 							SpansPerSecond: 50,
-							DurationCfg: &config.DurationCfg{
-								MinDurationMicros: 9000000,
+							PropertiesCfg: &config.PropertiesCfg{
+								MinDurationMicros: &minDurationValue,
 							},
 						},
 						{
@@ -94,9 +98,11 @@ func TestLoadConfig(t *testing.T) {
 				},
 				{
 					Name:            "test-policy-6",
-					Type:            config.Duration,
-					DurationCfg: config.DurationCfg{
-						MinDurationMicros: 100000,
+					Type:            config.Properties,
+					PropertiesCfg: config.PropertiesCfg{
+						NamePattern: &namePatternValue,
+						MinDurationMicros: &minDurationValue,
+						MinNumberOfSpans: &minSpansValue,
 					},
 				},
 			},

--- a/processor/samplingprocessor/tailsamplingprocessor/processor.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/processor.go
@@ -136,8 +136,8 @@ func getPolicyEvaluator(logger *zap.Logger, cfg *config.PolicyCfg) (sampling.Pol
 		return sampling.NewRateLimiting(logger, rlfCfg.SpansPerSecond), nil
 	case config.Cascading:
 		return sampling.NewCascadingFilter(logger, cfg)
-	case config.Duration:
-		return sampling.NewDurationFilter(logger, cfg.DurationCfg.MinDurationMicros), nil
+	case config.Properties:
+		return sampling.NewSpanPropertiesFilter(logger, cfg.PropertiesCfg.NamePattern, cfg.PropertiesCfg.MinDurationMicros, cfg.PropertiesCfg.MinNumberOfSpans)
 	default:
 		return nil, fmt.Errorf("unknown sampling policy type %s", cfg.Type)
 	}

--- a/processor/samplingprocessor/tailsamplingprocessor/sampling/cascading.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/sampling/cascading.go
@@ -40,7 +40,7 @@ type cascadingPolicy struct {
 }
 
 type cascadingRuleEvaluation struct {
-	// In fact, this can be only NumericTagFilter, StringTagFilter, Duration or AlwaysSample
+	// In fact, this can be only NumericTagFilter, StringTagFilter, Properties or AlwaysSample
 	evaluator PolicyEvaluator
 
 	context context.Context
@@ -125,7 +125,7 @@ func NewCascadingFilter(logger *zap.Logger, cfg *config.PolicyCfg) (PolicyEvalua
 		if ruleCfg.NumericAttributeCfg != nil {
 			attributesSet += 1
 		}
-		if ruleCfg.DurationCfg != nil {
+		if ruleCfg.PropertiesCfg != nil {
 			attributesSet += 1
 		}
 
@@ -142,8 +142,12 @@ func NewCascadingFilter(logger *zap.Logger, cfg *config.PolicyCfg) (PolicyEvalua
 				ruleCfg.NumericAttributeCfg.Key,
 				ruleCfg.NumericAttributeCfg.MinValue,
 				ruleCfg.NumericAttributeCfg.MaxValue)
-		} else if ruleCfg.DurationCfg != nil {
-			evaluator = NewDurationFilter(logger, ruleCfg.DurationCfg.MinDurationMicros)
+		} else if ruleCfg.PropertiesCfg != nil {
+			var err error
+			evaluator, err = NewSpanPropertiesFilter(logger, ruleCfg.PropertiesCfg.NamePattern, ruleCfg.PropertiesCfg.MinDurationMicros, ruleCfg.PropertiesCfg.MinNumberOfSpans)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		ctx, _ := tag.New(context.Background(), tag.Upsert(tagRuleKey, ruleCfg.Name))

--- a/processor/samplingprocessor/tailsamplingprocessor/sampling/cascading_test.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/sampling/cascading_test.go
@@ -72,6 +72,8 @@ func createTrace(numSpans int, durationMicros int64) *TraceData {
 }
 
 func createCascadingEvaluator() PolicyEvaluator {
+	testValue := int64(10000)
+
 	config := tsconfig.PolicyCfg{
 		Name:           "test-policy-5",
 		Type:           tsconfig.Cascading,
@@ -80,8 +82,8 @@ func createCascadingEvaluator() PolicyEvaluator {
 			{
 				Name:           "duration",
 				SpansPerSecond: 10,
-				DurationCfg: &tsconfig.DurationCfg{
-					MinDurationMicros: 10000,
+				PropertiesCfg: &tsconfig.PropertiesCfg{
+					MinDurationMicros: &testValue,
 				},
 			},
 			{

--- a/processor/samplingprocessor/tailsamplingprocessor/sampling/duration_filter.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/sampling/duration_filter.go
@@ -15,38 +15,59 @@
 package sampling
 
 import (
+	"errors"
+	"regexp"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"github.com/golang/protobuf/ptypes/timestamp"
-	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.uber.org/zap"
 )
 
-type durationFilter struct {
-	minDurationMicros int64
+type spanPropertiesFilter struct {
+	operationRe       *regexp.Regexp
+	minDurationMicros *int64
+	minNumberOfSpans  *int
 	logger            *zap.Logger
 }
 
-var _ PolicyEvaluator = (*durationFilter)(nil)
+var _ PolicyEvaluator = (*spanPropertiesFilter)(nil)
 
-// NewDurationFilter creates a policy evaluator that samples all traces with
-// the duration exceeding min duration
-func NewDurationFilter(logger *zap.Logger, minDurationMicros int64) PolicyEvaluator {
-	return &durationFilter{
-		minDurationMicros: minDurationMicros,
-		logger:            logger,
+// NewSpanPropertiesFilter creates a policy evaluator that samples all traces with
+// the specified criteria
+func NewSpanPropertiesFilter(logger *zap.Logger, operationNamePattern *string, minDurationMicros *int64, minNumberOfSpans *int) (PolicyEvaluator, error) {
+	var operationRe *regexp.Regexp
+	if operationNamePattern != nil {
+		var err error
+		operationRe, err = regexp.Compile(*operationNamePattern)
+		if err != nil {
+			return nil, err
+		}
 	}
+
+	if operationNamePattern == nil && minDurationMicros == nil && minNumberOfSpans == nil {
+		return nil, errors.New("at least one property must be defined")
+	}
+
+	return &spanPropertiesFilter{
+		operationRe:       operationRe,
+		minDurationMicros: minDurationMicros,
+		minNumberOfSpans:  minNumberOfSpans,
+		logger:            logger,
+	}, nil
 }
 
 // OnLateArrivingSpans notifies the evaluator that the given list of spans arrived
 // after the sampling decision was already taken for the trace.
 // This gives the evaluator a chance to log any message/metrics and/or update any
 // related internal state.
-func (df *durationFilter) OnLateArrivingSpans(earlyDecision Decision, spans []*tracepb.Span) error {
+func (df *spanPropertiesFilter) OnLateArrivingSpans(earlyDecision Decision, spans []*tracepb.Span) error {
 	return nil
 }
 
 // EvaluateSecondChance looks at the trace again and if it can/cannot be fit, returns a SamplingDecision
-func (df *durationFilter) EvaluateSecondChance(_ pdata.TraceID, trace *TraceData) (Decision, error) {
+func (df *spanPropertiesFilter) EvaluateSecondChance(_ pdata.TraceID, trace *TraceData) (Decision, error) {
 	return NotSampled, nil
 }
 
@@ -55,37 +76,68 @@ func tsToMicros(ts *timestamp.Timestamp) int64 {
 }
 
 // Evaluate looks at the trace data and returns a corresponding SamplingDecision.
-func (df *durationFilter) Evaluate(_ pdata.TraceID, trace *TraceData) (Decision, error) {
+func (df *spanPropertiesFilter) Evaluate(_ pdata.TraceID, trace *TraceData) (Decision, error) {
 	trace.Lock()
 	batches := trace.ReceivedBatches
 	trace.Unlock()
 
+	matchingOperationFound := false
+	spanCount := 0
 	minStartTime := int64(0)
 	maxEndTime := int64(0)
+
 	for _, batch := range batches {
+		spanCount += len(batch.Spans)
+
 		for _, span := range batch.Spans {
 			if span == nil {
 				continue
 			}
-			startTs := tsToMicros(span.StartTime)
-			endTs := tsToMicros(span.EndTime)
 
-			if minStartTime == 0 {
-				minStartTime = startTs
-				maxEndTime = endTs
-			} else {
-				if startTs < minStartTime {
-					minStartTime = startTs
+			if df.operationRe != nil && !matchingOperationFound {
+				if df.operationRe.MatchString(span.Name.Value) {
+					matchingOperationFound = true
 				}
-				if endTs > maxEndTime {
+			}
+
+			if df.minDurationMicros != nil {
+				startTs := tsToMicros(span.StartTime)
+				endTs := tsToMicros(span.EndTime)
+
+				if minStartTime == 0 {
+					minStartTime = startTs
 					maxEndTime = endTs
+				} else {
+					if startTs < minStartTime {
+						minStartTime = startTs
+					}
+					if endTs > maxEndTime {
+						maxEndTime = endTs
+					}
 				}
 			}
 		}
 	}
 
-	// Sanity check first
-	if maxEndTime > minStartTime && maxEndTime-minStartTime >= df.minDurationMicros {
+	operationNameConditionMet := true
+	minDurationConditionMet := true
+	minSpanCountConditionMet := true
+
+
+	if df.operationRe != nil {
+		operationNameConditionMet = matchingOperationFound
+	}
+
+	if df.minDurationMicros != nil {
+		// Sanity check first
+		minDurationConditionMet = maxEndTime > minStartTime && maxEndTime-minStartTime >= *df.minDurationMicros
+	}
+
+	if df.minNumberOfSpans != nil {
+		minSpanCountConditionMet = spanCount >= *df.minNumberOfSpans
+	}
+
+	if minDurationConditionMet && operationNameConditionMet && minSpanCountConditionMet {
 		return Sampled, nil
 	}
 
@@ -94,6 +146,6 @@ func (df *durationFilter) Evaluate(_ pdata.TraceID, trace *TraceData) (Decision,
 
 // OnDroppedSpans is called when the trace needs to be dropped, due to memory
 // pressure, before the decision_wait time has been reached.
-func (df *durationFilter) OnDroppedSpans(_ pdata.TraceID, _ *TraceData) (Decision, error) {
+func (df *spanPropertiesFilter) OnDroppedSpans(_ pdata.TraceID, _ *TraceData) (Decision, error) {
 	return NotSampled, nil
 }

--- a/processor/samplingprocessor/tailsamplingprocessor/sampling/span_properties_filter_test.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/sampling/span_properties_filter_test.go
@@ -1,0 +1,145 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling
+
+import (
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"testing"
+	"time"
+
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/consumer/consumerdata"
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+var operationNamePattern = "foo.*"
+var minDurationMicros = int64(500)
+var minNumberOfSpans = 2
+
+func TestInvalidArguments(t *testing.T) {
+	_, err := NewSpanPropertiesFilter(zap.NewNop(), nil, nil, nil)
+	assert.Error(t, err)
+}
+
+func TestPartialSpanPropertiesFilter(t *testing.T) {
+	opFilter, _ := NewSpanPropertiesFilter(zap.NewNop(), &operationNamePattern, nil, nil)
+	durationFilter, _ := NewSpanPropertiesFilter(zap.NewNop(), nil, &minDurationMicros, nil)
+	spansFilter, _ := NewSpanPropertiesFilter(zap.NewNop(), nil, nil, &minNumberOfSpans)
+
+	cases := []struct {
+		Desc     string
+		Evaluator PolicyEvaluator
+	}{
+		{
+			Desc:     "operation name filter",
+			Evaluator: opFilter,
+		},
+		{
+			Desc:     "duration filter",
+			Evaluator: durationFilter,
+		},
+		{
+			Desc:     "spans filter",
+			Evaluator: spansFilter,
+		},
+	}
+
+	matchingTraces := newTraceAttrs("foobar", 1000, 100)
+	nonMatchingTraces := newTraceAttrs("bar", 100, 1)
+
+	for _, c := range cases {
+		t.Run(c.Desc, func(t *testing.T) {
+			u, _ := uuid.NewRandom()
+			decision, err := c.Evaluator.Evaluate(pdata.NewTraceID(u[:]), matchingTraces)
+			assert.NoError(t, err)
+			assert.Equal(t, decision, Sampled)
+
+			u, _ = uuid.NewRandom()
+			decision, err = c.Evaluator.Evaluate(pdata.NewTraceID(u[:]), nonMatchingTraces)
+			assert.NoError(t, err)
+			assert.Equal(t, decision, NotSampled)
+		})
+	}
+}
+
+func TestSpanPropertiesFilter(t *testing.T) {
+	filter, _ := NewSpanPropertiesFilter(zap.NewNop(), &operationNamePattern, &minDurationMicros, &minNumberOfSpans)
+
+	cases := []struct {
+		Desc     string
+		Trace    *TraceData
+		Decision Decision
+	}{
+		{
+			Desc:     "fully matching",
+			Trace:    newTraceAttrs("foobar", 1000, 100),
+			Decision: Sampled,
+		},
+		{
+			Desc:     "nonmatching operation name",
+			Trace:    newTraceAttrs("non_matching", 1000, 100),
+			Decision: NotSampled,
+		},
+		{
+			Desc:     "nonmatching duration",
+			Trace:    newTraceAttrs("foobar", 100, 100),
+			Decision: NotSampled,
+		},
+		{
+			Desc:     "nonmatching number of spans",
+			Trace:    newTraceAttrs("foobar", 1000, 1),
+			Decision: NotSampled,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Desc, func(t *testing.T) {
+			u, _ := uuid.NewRandom()
+			decision, err := filter.Evaluate(pdata.NewTraceID(u[:]), c.Trace)
+			assert.NoError(t, err)
+			assert.Equal(t, decision, c.Decision)
+		})
+	}
+}
+
+func newTraceAttrs(operationName string, durationMicros int64, numberOfSpans int) *TraceData {
+	spans := make([]*tracepb.Span, 0)
+
+	startTs := timestamppb.New(time.Unix(1544712660, 0).UTC())
+	endTs := timestamppb.New(time.Unix(1544712660, 0).UTC().Add(time.Duration(durationMicros) * time.Microsecond))
+
+	for i := 0; i < numberOfSpans; i++ {
+		span := &tracepb.Span{
+			Name: &tracepb.TruncatableString{Value: operationName},
+			StartTime: startTs,
+			EndTime: endTs,
+		}
+
+		spans = append(spans, span)
+	}
+
+	return &TraceData{
+		ReceivedBatches: []consumerdata.TraceData{
+			{
+				Spans: spans,
+			},
+		},
+	}
+}
+

--- a/processor/samplingprocessor/tailsamplingprocessor/testdata/tail_sampling_config.yaml
+++ b/processor/samplingprocessor/tailsamplingprocessor/testdata/tail_sampling_config.yaml
@@ -43,7 +43,7 @@ processors:
               {
                 name: "dur",
                 spans_per_second: 50,
-                duration: {min_duration_micros: 9000000 }
+                properties: {min_duration_micros: 9000000 }
               },
               {
                 name: "everything_else",
@@ -53,8 +53,12 @@ processors:
          },
          {
             name: test-policy-6,
-            type: duration,
-            duration: {min_duration_micros: 100000}
+            type: properties,
+            properties: {
+              name_pattern: "foo.*",
+              min_number_of_spans: 10,
+              min_duration_micros: 9000000
+            }
          },
       ]
 


### PR DESCRIPTION
This converts duration filter into a more generic properties filter, which allows to include or exclude traces also basing on the number of spans or matching operation names